### PR TITLE
Update config.py to fix start failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,71 +4,85 @@
 
 Podimo is a proprietary podcasting player that enables you to listen to various exclusive shows behind a paywall.
 This tool allows you to stream Podimo podcasts with your preferred podcast player, without having to use the Podimo app.
+
 </div>
 
-
 ## Usage
+
 The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a Zenrows account to bypass Podimo's anti-bot mechanisms.
 
-## Setting up a Zenrows account
-You can create a free account, which gives you 1000 free api credits.
+## Setting up a ScraperAPI account
 
-1. Go to [app.zenrows.com/register](https://app.zenrows.com/register) and create a free account
-2. Copy your API key and make sure to add it to the `ZENROWS_API` environment variable (`-e`) in the Docker run command
+You can create a free account, which gives you 1000 free API credits per month.
+
+1. Go to [dashboard.scraperapi.com/signup](https://dashboard.scraperapi.com/signup) and create a free account
+2. Copy your API key and make sure to add it to the `SCRAPER_API` environment variable (`-e`) in the Docker run command
 
 ## Instructions for self-hosting (with Docker)
+
 1. Clone this repository and enter the newly created directory
+
 ```sh
 git clone https://github.com/ThijsRay/podimo
 cd podimo
 ```
 
 2. Build the Docker image
+
 ```sh
 docker build -t podimo:latest .
 ```
 
 3. Run the Docker image
+
 ```sh
 docker run --rm -e PODIMO_HOSTNAME=yourip:12104 -e PODIMO_BIND_HOST=0.0.0.0:12104 -e PODIMO_PROTOCOL=http -e ZENROWS_API=APIKEY -p 12104:12104 podimo:latest
 ```
+
 For an explaination of what each environmental variable (`-e`) does, see the section on [configuration with environmental variables](#configuration).
 
 4. Visit http://yourip:12104. You should see the site now!
 
 ## Installation for self-hosting (without Docker)
+
 Make sure you have a recent Python 3 version installed, as this is required for the steps below.
 
 1. Clone this repository and enter the newly created directory
+
 ```sh
 git clone https://github.com/ThijsRay/podimo
 cd podimo
 ```
 
 2. (Optional) Create a virtual environment to install the Python packages in
+
 ```sh
 vitualenv venv
 source venv/bin/activate
 ```
 
-3. Install the required packages with 
+3. Install the required packages with
+
 ```sh
 pip install -r requirements.txt
 ```
 
 4. Run the program with
+
 ```sh
 python main.py
 ```
+
 4. Visit http://localhost:12104. You should see the site now!
 
-
 ## Configuration
+
 There are a few environmental variables that can configure this tool
+
 - `PODIMO_HOSTNAME` Sets the hostname that is displayed in the interface to a custom value, defaults to `podimo.thijs.sh`
 - `PODIMO_BIND_HOST` Sets the IP and port to which this tool should bind, defaults to `127.0.0.1:12104`.
-- `PODIMO_PROTOCOL` Sets the protocol that is displayed in the interface. For local 
-deployments it can be useful to set this to `http`. Defaults to `https`.
+- `PODIMO_PROTOCOL` Sets the protocol that is displayed in the interface. For local
+  deployments it can be useful to set this to `http`. Defaults to `https`.
 - `ZENROWS_API` Sets the Zenrows API key for it to be used.
 - `DEBUG` Shows a bit more information that can be useful while debugging
 - `HTTP_PROXY` A URL for an HTTP proxy that can be used to rotate IP addresses to avoid being blocked by CloudFlare.
@@ -76,12 +90,15 @@ deployments it can be useful to set this to `http`. Defaults to `https`.
 Other configuration values can be found in `podimo/config.py`, but they generally don't have to be changed.
 
 ## Privacy
+
 The script keeps track of a few things in memory:
+
 - Your username and password, used to login and to create an access token. This is only used temporarily during a request itself.
 - A cryptographic hash that is calculated based on your username and password.
 - A Podimo access token, which is kept in memory for accessing pages after logging in.
 
 This data is _never_ written to the disk and it is _never_ logged. The hosted script on [podimo.thijs.sh](https://podimo.thijs.sh) runs behind an `nginx` reverse proxy that requires HTTPS and does not keep any logs. The `nginx` configuration is:
+
 ```nginx
 limit_req_zone $binary_remote_addr zone=podimo_limit:10m rate=1r/s;
 server {
@@ -106,7 +123,7 @@ server {
 
 	listen [::]:443 ssl ipv6only=on;
 	listen 443 ssl;
-	ssl_certificate /etc/letsencrypt/live/podimo.thijs.sh/fullchain.pem; 
+	ssl_certificate /etc/letsencrypt/live/podimo.thijs.sh/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/podimo.thijs.sh/privkey.pem;
 	include /etc/letsencrypt/options-ssl-nginx.conf;
 	ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
@@ -127,6 +144,7 @@ server {
 ```
 
 # License
+
 ```
 Copyright 2022 Thijs Raymakers
 
@@ -149,6 +167,7 @@ permissions and limitations under the Licence.
 ```
 
 # Support
+
 If you find this tool to be helpful, please consider buying me a coffee! It is greatly appreciated!
 
 <a href="https://www.buymeacoffee.com/thijsr"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=thijsr&button_colour=BD5FFF&font_colour=ffffff&font_family=Poppins&outline_colour=000000&coffee_colour=FFDD00" /></a>

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There are a few environmental variables that can configure this tool
 - `PODIMO_BIND_HOST` Sets the IP and port to which this tool should bind, defaults to `127.0.0.1:12104`.
 - `PODIMO_PROTOCOL` Sets the protocol that is displayed in the interface. For local
   deployments it can be useful to set this to `http`. Defaults to `https`.
-- `ZENROWS_API` Sets the Zenrows API key for it to be used.
+- `SCRAPER_API` Sets the ScraperAPI key for it to be used.
 - `DEBUG` Shows a bit more information that can be useful while debugging
 - `HTTP_PROXY` A URL for an HTTP proxy that can be used to rotate IP addresses to avoid being blocked by CloudFlare.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker build -t podimo:latest .
 3. Run the Docker image
 
 ```sh
-docker run --rm -e PODIMO_HOSTNAME=yourip:12104 -e PODIMO_BIND_HOST=0.0.0.0:12104 -e PODIMO_PROTOCOL=http -e ZENROWS_API=APIKEY -p 12104:12104 podimo:latest
+docker run --rm -e PODIMO_HOSTNAME=yourip:12104 -e PODIMO_BIND_HOST=0.0.0.0:12104 -e PODIMO_PROTOCOL=http -e SCRAPER_API=APIKEY -p 12104:12104 podimo:latest
 ```
 
 For an explaination of what each environmental variable (`-e`) does, see the section on [configuration with environmental variables](#configuration).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ This tool allows you to stream Podimo podcasts with your preferred podcast playe
 
 ## Usage
 
-The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a ScraperAPI account to bypass Podimo's anti-bot mechanisms.
+The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a Zenrows or ScraperAPI account to bypass Podimo's anti-bot mechanisms.
+
+## Setting up a Zenrows account
+You can create a free account, which gives you 1000 free api credits.
+
+1. Go to [app.zenrows.com/register](https://app.zenrows.com/register) and create a free account
+2. Copy your API key and make sure to add it to the `ZENROWS_API` environment variable (`-e`) in the Docker run command
 
 ## Setting up a ScraperAPI account
 
@@ -36,7 +42,7 @@ docker build -t podimo:latest .
 3. Run the Docker image
 
 ```sh
-docker run --rm -e PODIMO_HOSTNAME=yourip:12104 -e PODIMO_BIND_HOST=0.0.0.0:12104 -e PODIMO_PROTOCOL=http -e SCRAPER_API=APIKEY -p 12104:12104 podimo:latest
+docker run --rm -e PODIMO_HOSTNAME=yourip:12104 -e PODIMO_BIND_HOST=0.0.0.0:12104 -e PODIMO_PROTOCOL=http -e ZENROWS_API=APIKEY -e SCRAPER_API=APIKEY -p 12104:12104 podimo:latest
 ```
 
 For an explaination of what each environmental variable (`-e`) does, see the section on [configuration with environmental variables](#configuration).
@@ -83,6 +89,7 @@ There are a few environmental variables that can configure this tool
 - `PODIMO_BIND_HOST` Sets the IP and port to which this tool should bind, defaults to `127.0.0.1:12104`.
 - `PODIMO_PROTOCOL` Sets the protocol that is displayed in the interface. For local
   deployments it can be useful to set this to `http`. Defaults to `https`.
+- `ZENROWS_API` Sets the Zenrows API key for it to be used.
 - `SCRAPER_API` Sets the ScraperAPI API key for it to be used.
 - `DEBUG` Shows a bit more information that can be useful while debugging
 - `HTTP_PROXY` A URL for an HTTP proxy that can be used to rotate IP addresses to avoid being blocked by CloudFlare.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool allows you to stream Podimo podcasts with your preferred podcast playe
 
 ## Usage
 
-The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a Zenrows account to bypass Podimo's anti-bot mechanisms.
+The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a ScraperAPI account to bypass Podimo's anti-bot mechanisms.
 
 ## Setting up a ScraperAPI account
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There are a few environmental variables that can configure this tool
 - `PODIMO_BIND_HOST` Sets the IP and port to which this tool should bind, defaults to `127.0.0.1:12104`.
 - `PODIMO_PROTOCOL` Sets the protocol that is displayed in the interface. For local
   deployments it can be useful to set this to `http`. Defaults to `https`.
-- `SCRAPER_API` Sets the ScraperAPI key for it to be used.
+- `SCRAPER_API` Sets the ScraperAPI API key for it to be used.
 - `DEBUG` Shows a bit more information that can be useful while debugging
 - `HTTP_PROXY` A URL for an HTTP proxy that can be used to rotate IP addresses to avoid being blocked by CloudFlare.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool allows you to stream Podimo podcasts with your preferred podcast playe
 
 ## Usage
 
-The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to create a Zenrows or ScraperAPI account to bypass Podimo's anti-bot mechanisms.
+The easiest way to use it is via [podimo.thijs.sh](https://podimo.thijs.sh). You can also host it yourself by following the instructions below. It's necessary to either create a Zenrows or ScraperAPI account to bypass Podimo's anti-bot mechanisms.
 
 ## Setting up a Zenrows account
 You can create a free account, which gives you 1000 free api credits.

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -17,13 +17,15 @@
 # See the Licence for the specific language governing
 # permissions and limitations under the Licence.
 
-from podimo.config import GRAPHQL_URL, SCRAPER_API
+from podimo.config import GRAPHQL_URL, SCRAPER_API, ZENROWS_API
 from podimo.utils import (is_correct_email_address, token_key,
                           randomFlyerId, generateHeaders as gHdrs, debug,
                           async_wrap)
 from podimo.cache import insertIntoPodcastCache, getCacheEntry, podcast_cache
 from time import time
 import sys
+if ZENROWS_API is not None:
+    from zenrows import ZenRowsClient
 
 class PodimoClient:
     def __init__(self, username: str, password: str, region: str, locale: str):

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -55,7 +55,7 @@ class PodimoClient:
                                         headers=headers,
                                         cookies=self.cookie_jar,
                                         json={"query": query, "variables": variables},
-                                        timeout=(6.05, 12.05)
+                                        timeout=(6.05, 30)
                                     )
         if response is None:
             raise RuntimeError(f"Could not receive response for query: {query.strip()[:30]}...")

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -49,6 +49,9 @@ class PodimoClient:
     async def post(self, headers, query, variables, scraper):
         if SCRAPER_API is not None:
             POST_URL = f"https://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
+        elif ZENROWS_API is not None:
+            scraper = ZenRowsClient(ZENROWS_API)
+            POST_URL = GRAPHQL_URL
         else :
             POST_URL = GRAPHQL_URL
         response = await async_wrap(scraper.post)(POST_URL,

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -52,7 +52,7 @@ class PodimoClient:
         elif ZENROWS_API is not None:
             scraper = ZenRowsClient(ZENROWS_API)
             POST_URL = GRAPHQL_URL
-        else :
+        else:
             POST_URL = GRAPHQL_URL
         response = await async_wrap(scraper.post)(POST_URL,
                                         headers=headers,

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -48,7 +48,7 @@ class PodimoClient:
 
     async def post(self, headers, query, variables, scraper):
         if SCRAPER_API is not None:
-            POST_URL = f"http://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
+            POST_URL = f"https://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
         else :
             POST_URL = GRAPHQL_URL
         response = await async_wrap(scraper.post)(POST_URL,

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -24,7 +24,6 @@ from podimo.utils import (is_correct_email_address, token_key,
 from podimo.cache import insertIntoPodcastCache, getCacheEntry, podcast_cache
 from time import time
 import sys
-import requests
 
 class PodimoClient:
     def __init__(self, username: str, password: str, region: str, locale: str):
@@ -52,7 +51,7 @@ class PodimoClient:
             POST_URL = f"https://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
         else :
             POST_URL = GRAPHQL_URL
-        response = await async_wrap(requests.post)(POST_URL,
+        response = await async_wrap(scraper.post)(POST_URL,
                                         headers=headers,
                                         cookies=self.cookie_jar,
                                         json={"query": query, "variables": variables},

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -24,6 +24,7 @@ from podimo.utils import (is_correct_email_address, token_key,
 from podimo.cache import insertIntoPodcastCache, getCacheEntry, podcast_cache
 from time import time
 import sys
+import requests
 
 class PodimoClient:
     def __init__(self, username: str, password: str, region: str, locale: str):
@@ -51,7 +52,7 @@ class PodimoClient:
             POST_URL = f"https://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
         else :
             POST_URL = GRAPHQL_URL
-        response = await async_wrap(scraper.post)(POST_URL,
+        response = await async_wrap(requests.post)(POST_URL,
                                         headers=headers,
                                         cookies=self.cookie_jar,
                                         json={"query": query, "variables": variables},

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -48,7 +48,7 @@ class PodimoClient:
 
     async def post(self, headers, query, variables, scraper):
         if SCRAPER_API is not None:
-            POST_URL = f"https://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
+            POST_URL = f"http://api.scraperapi.com?api_key={SCRAPER_API}&url={GRAPHQL_URL}&keep_headers=true"
         else :
             POST_URL = GRAPHQL_URL
         response = await async_wrap(scraper.post)(POST_URL,

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -30,6 +30,7 @@ PODIMO_HOSTNAME = os.environ.get("PODIMO_HOSTNAME", "yourip:12104")
 PODIMO_BIND_HOST = os.environ.get("PODIMO_BIND_HOST", "0.0.0.0:12104")
 PODIMO_PROTOCOL = os.environ.get("PODIMO_PROTOCOL", "http")
 SCRAPER_API = os.environ.get("SCRAPER_API", None)
+ZENROWS_API = os.environ.get("ZENROWS_API", None)
 
 # Enable extra logging in debugging mode
 DEBUG = os.environ.get("DEBUG", False)

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -29,7 +29,7 @@ import os
 PODIMO_HOSTNAME = os.environ.get("PODIMO_HOSTNAME", "yourip:12104")
 PODIMO_BIND_HOST = os.environ.get("PODIMO_BIND_HOST", "0.0.0.0:12104")
 PODIMO_PROTOCOL = os.environ.get("PODIMO_PROTOCOL", "http")
-ZENROWS_API = os.environ.get("ZENROWS_API", None)
+SCRAPER_API = os.environ.get("SCRAPER_API", None)
 
 # Enable extra logging in debugging mode
 DEBUG = os.environ.get("DEBUG", False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ quart~=0.18.4
 hypercorn~=0.14.4
 cloudscraper~=1.2.71
 werkzeug~=2.3.7
+zenrows~=1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ quart~=0.18.4
 hypercorn~=0.14.4
 cloudscraper~=1.2.71
 werkzeug~=2.3.7
-zenrows~=1.3.2


### PR DESCRIPTION
Without ZENROWS_API defined this version of Podimo.py doesn't start:
`Dec 10 14:02:00 <host> podimo.py[4012688]: Traceback (most recent call last):
Dec 10 14:02:00 <host> podimo.py[4012688]:   File "/home/podimo/podimo/main.py", line 24, in <module>
Dec 10 14:02:00 <host> podimo.py[4012688]:     from podimo.client import PodimoClient
Dec 10 14:02:00 <host> podimo.py[4012688]:   File "/home/podimo/podimo-2023-12-10/podimo/client.py", line 20, in <module>
Dec 10 14:02:00 <host> podimo.py[4012688]:     from podimo.config import GRAPHQL_URL, SCRAPER_API, ZENROWS_API
Dec 10 14:02:00 <host> podimo.py[4012688]: ImportError: cannot import name 'ZENROWS_API' from 'podimo.config' (/home/podimo/podimo-2023-12-10/podimo/config.py)`